### PR TITLE
Fixed bug that input types are not added to definitions

### DIFF
--- a/src/Giraffe.Swagger/Dsl.fs
+++ b/src/Giraffe.Swagger/Dsl.fs
@@ -35,8 +35,20 @@ module Dsl =
                             p.Value
                             |> Seq.collect (
                                 fun v ->
-                                    v.Value.Responses |> Seq.choose(fun r -> r.Value.Schema)
-                                    |> Seq.collect(fun d -> d.FlattenComplexDefinitions()))
+                                    let inputTypes =
+                                         v.Value.Parameters
+                                        |> List.choose(fun (r : ParamDefinition) -> r.Type)
+                                        |> List.choose(fun (r : PropertyDefinition) ->
+                                            match r with
+                                            | Ref objectDef -> Some objectDef
+                                            | _ -> None)
+                                        |> List.collect(fun d -> d.FlattenComplexDefinitions())
+                                    let outputTypes =
+                                        v.Value.Responses
+                                        |> Seq.choose(fun r -> r.Value.Schema)
+                                        |> Seq.collect(fun d -> d.FlattenComplexDefinitions())
+                                        |> Seq.toList
+                                    (inputTypes @ outputTypes))
                     )
                     |> Seq.toList
                     |> List.distinct


### PR DESCRIPTION
If anyone is using this repo this could be a helpful fix that allows you to have different types for your input and output requests.